### PR TITLE
Donald/downloader duplicates

### DIFF
--- a/postgres_db/migrations/2022-06-08-155423_create_completed_downloads/up.sql
+++ b/postgres_db/migrations/2022-06-08-155423_create_completed_downloads/up.sql
@@ -1,7 +1,7 @@
 -- Your SQL goes here
 
 CREATE TABLE downloaded_tarballs (
-  tarball_url TEXT NOT NULL,
+  tarball_url TEXT PRIMARY KEY NOT NULL,
   downloaded_at TIMESTAMP WITH TIME ZONE NOT NULL,
 
   shasum TEXT,
@@ -12,7 +12,5 @@ CREATE TABLE downloaded_tarballs (
   signature0_keyid TEXT,
   npm_signature TEXT,
 
-  tgz_local_path TEXT NOT NULL,
-
-  PRIMARY KEY(tarball_url, downloaded_at)
+  tgz_local_path TEXT NOT NULL
 );

--- a/postgres_db/src/download_tarball.rs
+++ b/postgres_db/src/download_tarball.rs
@@ -4,6 +4,10 @@ use super::schema::downloaded_tarballs;
 use chrono::{DateTime, Utc};
 use diesel::Queryable;
 
+use diesel::prelude::*;
+use super::DbConnection;
+use super::schema;
+
 #[derive(Queryable, Insertable, Debug)]
 #[diesel(table_name = downloaded_tarballs)]
 pub struct DownloadedTarball {
@@ -42,3 +46,13 @@ impl DownloadedTarball {
     }
 }
 
+
+pub fn get_downloaded_urls_matching_tasks(conn: &DbConnection, chunk: &[DownloadTask]) -> Vec<String> {
+    use schema::downloaded_tarballs::dsl::*;
+
+    downloaded_tarballs
+        .select(tarball_url)
+        .filter(tarball_url.eq_any(chunk.iter().map(|t| &t.url)))
+        .load(&conn.conn)
+        .expect("Error checking for max sequence in change_log table")
+}


### PR DESCRIPTION
This PR does 2 things:
1. Handle duplicate download requests (rare but possible) gracefully. We remove primary key on downloaded time of a tarball so that duplicates can't be written into the table.
2. Change the download queuer to only enqueue URLs if they haven't already been downloaded successfully.